### PR TITLE
Add Basilisk Step Studio to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Download: [SolidOut for macOS (Apple silicon)](https://github.com/BlinkingSun/st
 
 ---
 
+## Basilisk Step Studio: the desktop app (Windows)
+
+**Basilisk Step Studio** is a Windows interface over this engine, built by [Dominic Tursini](https://github.com/Dom-Tursini) of [Apex Invent](https://github.com/ApexInvent): drop STL files on the window, queue as many as you like, convert with Verbatim or TrueForm and check the result in a viewer that draws the engine's own B-Rep edges over the converted solid, which is the quickest way to see whether a face was really recovered or just re-triangulated. The command line stays on screen and works in both directions, so an existing stl2step invocation can be pasted in and the options fill from it. The engine and OpenCASCADE are bundled, so nothing else needs to be installed.
+
+Download: [Basilisk Step Studio for Windows](https://github.com/ApexInvent/Basilisk-Step-Studio/releases/latest) from its [releases page](https://github.com/ApexInvent/Basilisk-Step-Studio/releases). The engine is compiled from this repository at the pinned tag against OpenCASCADE 7.9.3 by a public workflow.
+
+---
+
 ## Dependencies
 
 - A **C++17** compiler (Clang, GCC, or MSVC).


### PR DESCRIPTION
Hello, and thanks for stl2step. The conversion quality is the reason this exists.

I have built a Windows interface over the engine, and this adds it to the README as a counterpart to the SolidOut section, in the same shape and place.

**Basilisk Step Studio** bundles the engine and OpenCASCADE, so Windows users get the conversion without a compiler or a terminal. It queues files, shows the result in a viewer that draws the `--edges` B-Rep boundaries over the tessellation, and keeps the command line visible and editable in both directions.

A few things you may want to know before merging:

- The engine is compiled unmodified from this repository at the pinned tag, against OpenCASCADE 7.9.3, by a public workflow. Nothing is forked or patched.
- Your MIT licence and the OCCT LGPL terms are both carried, with the notice the OCCT exception asks for, since the installer redistributes the kernel.
- The README credits stl2step for all conversion. The interface does no geometry of its own.

I left screenshots out to keep the diff small, but I am happy to add one if you would like the section to match SolidOut more closely. Equally happy to shorten it, move it, or for you to close this if you would rather not list third party front-ends at all.

https://github.com/ApexInvent/Basilisk-Step-Studio